### PR TITLE
Remove the minimum-stability option in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "noxxienl/nladdresslexer",
     "description": "Package to evaluate and parse dutch addresses",
     "type": "library",
-    "minimum-stability": "dev",
     "prefer-stable": true,
 
     "require": {


### PR DESCRIPTION
In order to be used in major projects, please remove the minimum-stability and deploy.